### PR TITLE
Fix related to saving the results in excel for evaluation

### DIFF
--- a/Evaluation/RAG_Evaluator/src/main.py
+++ b/Evaluation/RAG_Evaluator/src/main.py
@@ -89,18 +89,19 @@ def evaluate_with_ragas_and_crag(excel_file, sheet_name, config, run_ragas=True,
 
         ragas_results = pd.DataFrame([])
         crag_results = pd.DataFrame([])
+        total_set_result = {}  # Initialize as empty dict instead of None
 
         if run_ragas:
             ragas_evaluator = RagasEvaluator()
-            ragas_results = ragas_evaluator.evaluate(queries, answers, ground_truths, contexts, model=llm_model)
+            ragas_eval_result = ragas_evaluator.evaluate(queries, answers, ground_truths, contexts, model=llm_model)
+            ragas_results = ragas_eval_result[0]  # DataFrame
+            total_set_result = ragas_eval_result[1].__dict__ if len(ragas_eval_result) > 1 else {}  # Convert result object to dict
 
         if run_crag:
             openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
             crag_evaluator = CragEvaluator(config['openai']['model_name'], openai_client)
             crag_results = crag_evaluator.evaluate(queries, answers, ground_truths, contexts)
             
-        total_set_result = ragas_results[1] if run_ragas and len(ragas_results) > 1 else None
-        ragas_results = ragas_results[0] if run_ragas and len(ragas_results) > 1 else ragas_results
         result_converter = ResultsConverter(ragas_results, crag_results)
 
         if run_ragas:
@@ -109,19 +110,20 @@ def evaluate_with_ragas_and_crag(excel_file, sheet_name, config, run_ragas=True,
         if run_crag:
             result_converter.convert_crag_results()
 
+        # Single return point based on review feedback
+        final_results = pd.DataFrame([])
         if len(ragas_results.index) > 0 and len(crag_results.index) > 0:
-            combined_results = result_converter.get_combined_results()
-            return combined_results, total_set_result
+            final_results = result_converter.get_combined_results()
         elif len(ragas_results.index) > 0:
-            return result_converter.get_ragas_results(), total_set_result   
+            final_results = result_converter.get_ragas_results()
         elif len(crag_results.index) > 0:
-            return result_converter.get_crag_results(), total_set_result
-        else:
-            # Return empty dataframe if no results
-            return pd.DataFrame([]), None
+            final_results = result_converter.get_crag_results()
+        
+        return final_results, total_set_result
+        
     except Exception as e:
         print("Encountered error while running evaluation: ", traceback.format_exc())
-        return pd.DataFrame([]), None
+        return pd.DataFrame([]), {}
 
 # for running from api
 def run(input_file, sheet_name="", evaluate_ragas=False, evaluate_crag=False, use_search_api=False, llm_model=None, save_db=False):
@@ -164,12 +166,16 @@ def run(input_file, sheet_name="", evaluate_ragas=False, evaluate_crag=False, us
                                                     run_ragas=run_ragas,
                                                     use_search_api=use_search_api, 
                                                     llm_model=llm_model)
-                results[0].to_excel(writer, sheet_name=sheet_name, index=False)
-                if(save_db):
-                    dbService(results[0], results[1], timestamp)
-
-                print(f"Results for sheet '{sheet_name}' saved to '{output_filename}'.")
                 
+                # Handle the case where results might be None or empty
+                if results and len(results) >= 1 and not results[0].empty:
+                    results[0].to_excel(writer, sheet_name=sheet_name, index=False)
+                    if(save_db):
+                        dbService(results[0], results[1], timestamp)
+                    print(f"Results for sheet '{sheet_name}' saved to '{output_filename}'.")
+                else:
+                    print(f"No results to save for sheet '{sheet_name}'. Skipping.")
+
         print(f"All results have been saved to '{output_filename}'.")
         return f"All results have been saved to '{output_filename}'."
     except Exception as e:


### PR DESCRIPTION
**Issue:**

The evaluate_with_ragas_and_crag function currently has inconsistent return types:
- If both RAGAS and CRAG results exist: it returns combined_results (a single value, e.g., a DataFrame).
- If only RAGAS results exist: it returns a tuple (ragas_results, total_set_result).
- If only CRAG results exist: it returns crag_results (a single value).
- If an exception occurs: it implicitly returns None.

This inconsistency causes errors because the calling code assumes the function always returns a tuple and tries to access results[0]. This fails when the function returns only a single DataFrame or None.

**Fix:**

Ensure a consistent return type:
- Always return a tuple (results_df, total_set_result)
- If both RAGAS and CRAG are used: return (combined_results, total_set_result).
- If only one is used: return (ragas_results or crag_results, total_set_result).
- If an exception occurs: return (empty DataFrame, None).

Add safe access:

 In the calling code, check if results[0] is not empty before using the DataFrame.

**Prevent empty Excel files:**

 Only write results to Excel if the DataFrame is not empty — this avoids IndexError: At least one sheet must be visible.

**This ensures:**

- No KeyError: 0 (due to indexing a non-tuple).
- No IndexError when exporting to Excel with no data.
- Predictable behavior for any downstream logic.
